### PR TITLE
getStatus Added

### DIFF
--- a/www/dropbox-sync.js
+++ b/www/dropbox-sync.js
@@ -79,4 +79,8 @@ DropboxSync.prototype.openFile = function(dropboxFilePath, successCB, failCB) {
     exec(successCB, failCB, pluginName, 'openFile', [dropboxFilePath]);
 };
 
+DropboxSync.prototype.getStatus = function(dropboxFilePath, successCB, failCB) {
+    exec(successCB, failCB, pluginName, 'getStatus', [dropboxFilePath]);
+};
+
 module.exports = new DropboxSync();


### PR DESCRIPTION
gives the caching status of a file. returns "giving null status", or "cached latest", "cached not latest" or "not cached"

DropboxSync.getStatus(filePath, function(result) { 
    alert(result); 
    // success
    // Android device will either open the file with the proper external application
    // installed on your device or ask you which application to use.
}, function(e) { // fail
    alert(e);
   // Handle error in fail callback.
});
